### PR TITLE
Add transitive attributes support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,8 @@ jobs:
       - name: build all workspace crates
         run: cargo build --verbose --all
 
-      - name: "macro: all expected OK cases"
-        run: cargo test --package parameterized-macro --test tests expected_ok_all -- --exact
-
-      - name: "macro: all expected FAIL cases"
-        run: cargo test --package parameterized-macro --test tests expected_failures -- --exact
+      - name: "run all default features tests"
+        run: cargo test --all
 
   rustfmt:
     name: rustfmt

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -29,6 +29,7 @@ pub fn parameterized(
     let vis = &func.vis;
     let func_args = &func.sig.inputs;
     let body_block = &func.block;
+    let attributes = &func.attrs;
 
     let mod_name = format!("{}", name);
     let mod_ident = syn::Ident::new(mod_name.as_str(), name.span());
@@ -53,9 +54,9 @@ pub fn parameterized(
     // step 3
     //
     // now we need to create test cases, one for each EXPR, consisting of:
-    // - `let #ident: #ty = #expr;` bind at the start of the fn, #ident is key of the map,
+    // * `let #ident: #ty = #expr;` bind at the start of the fn, #ident is key of the map,
     //      #ty is the matching fn param, #expr is the current expr
-    // - then append the body (block) of the fn
+    // * then append the body (block) of the fn
     //
 
     let identifiers_defined = args.args.len();
@@ -133,6 +134,7 @@ pub fn parameterized(
 
         quote! {
             #[test]
+            #(#attributes)*
             #vis fn #ident() {
                 #(#binds)*
 

--- a/macro/tests/cases.rs
+++ b/macro/tests/cases.rs
@@ -29,6 +29,7 @@ fn individual_cases() {
     t.pass("tests/ok/11_enum.rs");
     t.pass("tests/ok/12_enum_with_variant_value.rs");
     t.pass("tests/ok/13_import_rename.rs");
+    t.pass("tests/ok/14_transitive_attr.rs");
 
     t.compile_fail("tests/fail/id_already_defined.rs");
     t.compile_fail("tests/fail/inequal_amount_of_arg.rs");

--- a/macro/tests/ok/14_transitive_attr.rs
+++ b/macro/tests/ok/14_transitive_attr.rs
@@ -1,0 +1,7 @@
+use parameterized_macro::parameterized;
+
+#[parameterized(number = { 1, 2, 3 })]
+#[should_panic]
+fn my_test(number: i32) {}
+
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,18 @@
 extern crate parameterized_macro;
 
 pub use parameterized_macro::parameterized;
+
+#[cfg(test)]
+mod transitive_attrs {
+    use super::parameterized as pm;
+
+    // for intellij-rust
+    #[test]
+    fn _mark_module_as_test() {}
+
+    #[pm(input = { None, None, None })]
+    #[should_panic]
+    fn numbers(input: Option<()>) {
+        input.unwrap()
+    }
+}


### PR DESCRIPTION
Use case:
(1) A test case can be marked with the #[should_panic] attribute, so
    a test would succeed if it panicked, and fail if it did not panic.

Currently however, we did not propagate (other) attributes on the parameterized
marked test function.
This commit ensures that other attributes placed on top of a parameterized
test function will also be included in all generated paramaterized test cases.