### PR TITLE
Add declarative ide! macro as workaround to enable intellij run context menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,34 @@ Procedural macro which allows you to define a test to be run with multiple (opti
 Test cases are defined using the 'parameterized' attribute instead of the 'test' attribute.
 This crate was inspired by JUnit `@ParameterizedTest`.
 
-## Example:
+### Examples:
+
+**Example: Add5**
+
+```rust
+fn add5<T: Into<u32>>(component: T) -> u32 {
+    component.into() + 5
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parameterized::parameterized;
+
+    ide!();
+
+    #[parameterized(input = {
+        0, 1, 2
+    }, expected = {
+        5, 6, 7
+    })]
+    fn test_add5(input: u16, expected: u32) {
+        assert_eq!(add5(input), expected);
+    }
+}
+```
+
+**Example: Fruits**
 
 ```rust
 enum Fruit {
@@ -63,7 +90,48 @@ and in the <a href="macro/tests">tests</a> folder.
 
 <br>
 
-#### License
+### Imports
+
+If you prefer not to import this library with `use parameterized::parameterized;` in every test case, you can put
+the following snippet at the top of your crate root:
+```rust
+#[cfg(test)]
+#[macro_use]
+extern crate parameterized;
+```
+
+### IDE 'run test' intent
+
+IntelliJ IDEA recognizes test cases and provides context menu's which allow you to run tests within a certain scope
+(such as a module or a single test case). For example, in IntelliJ you can usually run individual test cases by clicking
+the ▶ icon in the gutter. Unfortunately, attribute macros are currently not expanded by `intellij-rust`.
+This means that the IDE will not recognize test cases generated as a result of attribute macros (such as the
+`parameterized` macro published by this crate). As a partial work around, you can create an empty test case which
+will mark the module as containing test cases and in the gutter you will find a ▶ icon next to the module. This allows
+you to run test cases per module. This crate provides a macro called `ide!()` which creates an empty test case for
+the above purpose.
+
+Note: `intellij-rust` does expand declarative macro's (at least with the new macro engine which can be
+selected in the 'settings' menu), such as this `ide!` macro.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use parameterized::parameterized as pm;
+    use parameterized::ide;
+
+    ide!();
+
+    #[pm(input = { 2, 3, 4 }, output = { 4, 6, 8 })]
+    fn test_add2(input: i32, output: i32) {
+        let add2 = |receiver: i32| { receiver + 2 };
+
+        assert_eq(add2(input), output);
+    }
+}
+```
+
+### License
 
 Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
 2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,70 @@ extern crate parameterized_macro;
 
 pub use parameterized_macro::parameterized;
 
+/// Attribute macro's such as 'parameterized' do not enable the run tests intent for a module
+/// marked as cfg(test) (or a #[test] function for that matter) in Intellij.
+///
+/// To enable the intent within a module, we need at least a single test marked with `#[test]`.
+/// The `ide!()` macro is a work around for this issue and creates this empty test. It can be called
+/// within every module where we wish to run test cases using the run configuration / run test context
+/// menu.
+///
+/// Using the intellij-rust new macro expansion engine, if this macro is called within a module,
+/// the module will be marked as test, and the 'run as test' context menu will be provided in the
+/// gutter.
+#[macro_export]
+macro_rules! ide {
+    () => {
+        #[test]
+        fn __mark_with_test_intent() {}
+    };
+}
+
 #[cfg(test)]
-mod transitive_attrs {
+mod tests {
     use super::parameterized as pm;
 
-    // for intellij-rust
-    #[test]
-    fn _mark_module_as_test() {}
+    fn add5<T: Into<u32>>(component: T) -> u32 {
+        component.into() + 5
+    }
 
-    #[pm(input = { None, None, None })]
-    #[should_panic]
-    fn numbers(input: Option<()>) {
-        input.unwrap()
+    mod readme_test {
+        use super::*;
+
+        ide!();
+
+        #[pm(input = {
+            0, 1, 2
+        }, expected = {
+            5, 6, 7
+        })]
+        fn test_add5(input: u16, expected: u32) {
+            assert_eq!(add5(input), expected)
+        }
+    }
+
+    mod marked_as_test_module {
+        use super::*;
+
+        ide!();
+
+        #[pm(input = { 2, 3, 4 }, output = { 4, 6, 8 })]
+        fn test_times2(input: i32, output: i32) {
+            let times2 = |receiver: i32| receiver * 2;
+
+            assert_eq!(times2(input), output);
+        }
+    }
+
+    mod transitive_attrs {
+        use super::*;
+
+        ide!();
+
+        #[pm(input = { None, None, None })]
+        #[should_panic]
+        fn numbers(input: Option<()>) {
+            input.unwrap()
+        }
     }
 }


### PR DESCRIPTION
A run context menu is usually available for test cases and other run actions
such as run main(). Since attribute macros are not expanded by the
intellij-rust plugin, test cases are not recognized as such by intellij.

Declarative macros do get expanded by the new macro expansion engine.
By creating a single empty test in a module we can mark the module so
intellij will recognize it contains test cases.

This empty test can be created with calling the 'ide!()' macro.