### PR TITLE
Accept an alternative workaround for the IDE test intent issue

### DIFF
--- a/macro/readme.md
+++ b/macro/readme.md
@@ -51,11 +51,3 @@ More examples can be found in the `expand` crate, and the tests.
 - Tests executed from the workspace crate should be run individually, e.g.
     (`cargo test --package parameterized-macro --test tests individual_cases -- --exact`).
     Otherwise, if just `cargo test` is used, some generated test cases will run in an incorrect context setting.
-
-#### todo's and fixme's:
-- see 'fixme' in code comments
-- see 'tests/todo' test cases
-
-- propagate other attributes to the generated test cases
-- use `heck` crate to fix casing
-- the current code base is a first version; the code is not always particularly pretty.

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -29,7 +29,11 @@ pub fn parameterized(
     let vis = &func.vis;
     let func_args = &func.sig.inputs;
     let body_block = &func.block;
-    let attributes = &func.attrs;
+    let mut attributes = func.attrs.to_vec();
+
+    // removes the last defined `#[test]` attribute (only if defined after the #[parameterized(...)]
+    // attribute)
+    remove_test_attribute(&mut attributes);
 
     let mod_name = format!("{}", name);
     let mod_ident = syn::Ident::new(mod_name.as_str(), name.span());
@@ -154,6 +158,49 @@ pub fn parameterized(
     };
 
     token_stream.into()
+}
+
+/// Remove the last attribute (after any parameterized attribute) named 'test'.
+///
+///
+/// This allows developers using IDE's which do not expand attribute macros (such as
+/// intellij-rust) to use IDE features which rely on the expansion of said macros (such as 'run test'
+/// gutter functionality in Intellij IDEA) to annotate their test functions with both the
+/// parameterized attribute, and the test attribute. The test attribute has to be defined after
+/// the parameterized attribute!
+/// Two advantages of this approach over tricking the IDE by defining an declarative macro
+/// which defines an empty test case are: 1) we are not dependent on having an IDE which can expand
+/// declarative macros and 2) we don't need to stick our test cases into modules as to only run
+/// the test cases defined for that module.
+///
+///
+/// An example:
+/// ```
+/// use parameterized_macro::parameterized;
+///
+/// fn squared(input: i8) -> i8 {
+///   input * input
+/// }
+///
+/// #[parameterized(input = {
+///     -2, -1, 0, 1, 2
+/// }, expected = {
+///     4, 1, 0, 1, 4
+/// })]
+/// #[test] // <--
+/// fn my_parameterized_test(input: i8, expected: i8) {
+///     assert_eq!(squared(input), expected);
+/// }
+/// ```
+///
+/// Implementation based on [datatest](https://github.com/commure/datatest/blob/122f112705bbcbdbea430bf7cad0321d97d5fb4a/datatest-derive/src/lib.rs#L326-L335)
+///   which is licensed under the Apache-2.0 OR MIT license.
+/// Suggested by [Ivan Dubrov](https://github.com/foresterre/parameterized/issues/21#issuecomment-575834515).
+fn remove_test_attribute(attributes: &mut Vec<syn::Attribute>) {
+    attributes
+        .into_iter()
+        .rposition(|attr| attr.path.is_ident("test"))
+        .map(|pos| attributes.remove(pos));
 }
 
 /// Checks whether all inputs have equal length.


### PR DESCRIPTION
The test intent issue can be summarized as: "IDE's recognize #[test] attributes and provide useful
'run test' intents through their UI", but if test cases decorated by a #[test] attribute are generated
by a procedural macro, the IDE needs to be capable of expanding procedural macros." Most (all current?)
IDE's do not (yet) have this capability. Because these test intents can be practical during development
we attempt to provide workarounds.

The added workaround allows you to write a `#[test]` attribute after the `#[parameterized(...)]` attribute.
Because of parsing visibility, the parameterized attribute macro can't inspect any attribute defined
before itself (thus the ordering of attributes matters for this workaround!).

Two advantages of this approach over the original ide!() macro are: 1) we are not dependent on having an IDE
which is capable of expanding declarative macros, and 2) we don't need to stick our test cases into modules
as to only run the tests cases for one parameterized test function.

closes #23 