### PR TITLE
Remove mention about not needing to add modules around tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ The first lets you add the `#[test]` attribute after the `#[parameterized(...)]`
 the parameterized attribute macro can't inspect any attribute defined before itself (thus attribute ordering matters for
 this workaround!).
 
-Two advantages of this approach over the second approach mentioned below are: we are not dependent on having an IDE
-which can expand declarative macros, and we don't need to stick our test cases into modules as to only run the tests
-cases for one parameterized test function.
-
-Thanks for the suggestion [Ivan Dubrov](https://github.com/foresterre/parameterized/issues/21#issuecomment-575834515)!
+An advantage of this approach over the second approach mentioned below is: we are not dependent on having an IDE
+which can expand declarative macros. A disadvantage may be that the IDE will show the ▶ icon next to the test case; and
+clicking on it may not produce the results which one would expect. The IDE may not receive the correct test intents, 
+or any intent at all. We are looking into finding a way to work around this in particular. In any case, thanks for the
+suggestion [Ivan Dubrov](https://github.com/foresterre/parameterized/issues/21#issuecomment-575834515).
 
 ```rust
 fn squared(input: i8) -> i8 {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -168,10 +168,9 @@ pub fn parameterized(
 /// gutter functionality in Intellij IDEA) to annotate their test functions with both the
 /// parameterized attribute, and the test attribute. The test attribute has to be defined after
 /// the parameterized attribute!
-/// Two advantages of this approach over tricking the IDE by defining an declarative macro
-/// which defines an empty test case are: 1) we are not dependent on having an IDE which can expand
-/// declarative macros and 2) we don't need to stick our test cases into modules as to only run
-/// the test cases defined for that module.
+/// An advantages of this approach over tricking the IDE by defining an declarative macro
+/// which defines an empty test case is that we are not dependent on having an IDE which can expand
+/// declarative macros.
 ///
 ///
 /// An example:
@@ -193,9 +192,8 @@ pub fn parameterized(
 /// }
 /// ```
 ///
-/// Implementation based on [datatest](https://github.com/commure/datatest/blob/122f112705bbcbdbea430bf7cad0321d97d5fb4a/datatest-derive/src/lib.rs#L326-L335)
-///   which is licensed under the Apache-2.0 OR MIT license.
-/// Suggested by [Ivan Dubrov](https://github.com/foresterre/parameterized/issues/21#issuecomment-575834515).
+/// Implementation based on [datatest](https://github.com/commure/datatest/blob/122f112705bbcbdbea430bf7cad0321d97d5fb4a/datatest-derive/src/lib.rs#L326-L335),
+///   which is licensed under the Apache-2.0 OR MIT license. Suggested by [Ivan Dubrov](https://github.com/foresterre/parameterized/issues/21#issuecomment-575834515).
 fn remove_test_attribute(attributes: &mut Vec<syn::Attribute>) {
     attributes
         .into_iter()


### PR DESCRIPTION
Intellij seems to not receive test events if you click on the run tests
icon next to the parameterized test in the gutter.

I acted to quickly expecting it would work; since an icon did show up in the doc comment test code I wrote. Oops, learning moment! 

relevant issues: #23 