### PR TITLE
Update syn to 1.0.58 and fix issue where a private module was used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,6 @@ jobs:
           command: test
           args: --verbose --all
 
-      - name: test.workspace.spec_valuesource
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all --no-default-features --features valuesource
-
-      - name: test.workspace.spec_casebycase
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all --no-default-features --features casebycase
-
   rustfmt:
     name: pipeline.rustfmt
     runs-on: ubuntu-18.04
@@ -118,13 +106,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace
-      - name: check.clippy.spec_valuesource
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --no-default-features --features valuesource --workspace
-      - name: check.clippy.spec_casebycase
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --no-default-features --features casebycase --workspace

--- a/parameterized-macro/Cargo.toml
+++ b/parameterized-macro/Cargo.toml
@@ -21,9 +21,9 @@ name = "tests"
 path = "tests/cases.rs"
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "1", features = ["full"] }
+proc-macro2 = "1.0.24"
+quote = "1.0.8"
+syn = { version = "1.0.58", features = ["full"] }
 linked-hash-map = { version = "0.5.3" }
 
 [dev-dependencies]

--- a/parameterized-macro/src/impls/mod.rs
+++ b/parameterized-macro/src/impls/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod restructure;
 mod validation;
 
+use std::fmt::Formatter;
 use syn::braced;
-use syn::export::Formatter;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 


### PR DESCRIPTION
> In syn versions <= 1.0.57, the syn::export module is pub (i.e. you can import it) but documented as being an implementation detail that's not considered part of the public API. syn v1.0.58 reinforces this by moving the module to a new path, syn::__private: dtolnay/syn@957840e. Because this crate makes use of syn::export it will not build with the latest syn (confirmed by checking out the repo and running cargo build).
-- Cole Miller in #36 

fixes #36