### PR TITLE
Replace linked-hash-map with indexmap

### DIFF
--- a/parameterized-macro/Cargo.toml
+++ b/parameterized-macro/Cargo.toml
@@ -23,8 +23,14 @@ path = "tests/cases.rs"
 [dependencies]
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
-syn = { version = "1.0.58", features = ["full"] }
-linked-hash-map = { version = "0.5.3" }
+
+[dependencies.syn]
+version = "1.0.58"
+features = ["full"]
+
+[dependencies.indexmap]
+version = "1.6.2"
+default-features = false
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/parameterized-macro/src/impls/restructure.rs
+++ b/parameterized-macro/src/impls/restructure.rs
@@ -1,4 +1,4 @@
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::spanned::Spanned;
@@ -30,7 +30,7 @@ pub(crate) fn impl_value_source(
                 v.param_args.iter().cloned().collect::<Vec<syn::Expr>>(),
             )
         })
-        .collect::<LinkedHashMap<syn::Ident, Vec<syn::Expr>>>();
+        .collect::<IndexMap<syn::Ident, Vec<syn::Expr>>>();
 
     // interlude: ensure that the parameterized test definition contain unique identifiers.
     if values.len() != identifiers_len {

--- a/parameterized-macro/src/impls/validation.rs
+++ b/parameterized-macro/src/impls/validation.rs
@@ -1,6 +1,6 @@
 #![cfg(not(matrix))]
 
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
 use std::fmt::Display;
 
 /// Checks whether all inputs have equal length.
@@ -12,7 +12,7 @@ use std::fmt::Display;
 /// the first test shall define `"a"` and `1`, the second `"b"` and 2, but for the third case,
 /// a value for `v` exists (namely `"c"`), however no value to substitute for `w` exists.
 /// Therefore, no fully valid set of tests can be constructed from the parameterized definition.
-pub(crate) fn check_all_input_lengths(map: &LinkedHashMap<syn::Ident, Vec<syn::Expr>>) -> usize {
+pub(crate) fn check_all_input_lengths(map: &IndexMap<syn::Ident, Vec<syn::Expr>>) -> usize {
     let mut arguments: Option<usize> = None;
     for (ident, values) in map.iter() {
         match arguments {


### PR DESCRIPTION
Index map is in more widespread use, tested in more depth, avoids more unsafe code usage and is more actively maintained.