### PR TITLE
Publish 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 msrv = "1.36.0"
 
 [dependencies]
-parameterized-macro = { path = "parameterized-macro", version = "=0.3.1" }
+parameterized-macro = { path = "parameterized-macro", version = "1" }
 
 [workspace]
 members = ["parameterized-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parameterized"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/parameterized-macro/Cargo.toml
+++ b/parameterized-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parameterized-macro"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The library has been in use for about 3 years, and is used as if the version was stable.
The new 1.0.0 version will reflect this.

If breaking changes are needed, we'll consider bumping to 2.0.0, which is not a sin :).

Open considerations for future versions are updating the indexmap dependency; but this is no priority. The changeset (https://github.com/bluss/indexmap/compare/1.6.2...1.8.1), contains no changes which would be important to us. In addition, it would increase our MSRV from `1.38` to `1.56`.