### PR TITLE
Release parameterized 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ which provides an attribute macro, to be used for parameterized testing.
 If you found an issue, have a suggestion or want to provide feedback or insights, please feel free to open an issue on
 the [issue tracker](https://github.com/foresterre/parameterized/issues), or open a topic in the [discussions section](https://github.com/foresterre/parameterized/discussions).
 
+## [1.0.1] - 2022-11-09
+
+### Changed
+
+* Updated MSRV to Rust `1.38`
+* Updated parameterized-macro to `1.0.1`
+
+[1.0.1]: https://github.com/foresterre/parameterized/releases/tag/v1.0.1
+
 ## [1.0.0] - 2022-05-02
 
 ### Changed
 
-* MSRV is now `1.38`
+* Updated MSRV to Rust `1.36`
 
 [1.0.0]: https://github.com/foresterre/parameterized/releases/tag/v1.0.0
 

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -42,7 +42,7 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "parameterized"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "parameterized-macro",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parameterized"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
There are no changes except for a dependency update, and an MSRV increase from 1.36 to 1.38